### PR TITLE
Consider changing default host from localhost to 0.0.0.0

### DIFF
--- a/src/Efficiently/Larasset/Commands/ServeAssetsCommand.php
+++ b/src/Efficiently/Larasset/Commands/ServeAssetsCommand.php
@@ -88,7 +88,7 @@ class ServeAssetsCommand extends AssetsCommand
     protected function getOptions()
     {
         return [
-            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the asset files on.', "localhost"],
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the asset files on.', "0.0.0.0"],
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the asset files on.', config('larasset.port', 3000)],
             ['assets-env', null, InputOption::VALUE_OPTIONAL, 'Specifies the assets environment to run this server under (test/development/production).', 'development'],
             ['environment', null, InputOption::VALUE_OPTIONAL, "DEPRECATED: Use '--assets-env' option instead."],


### PR DESCRIPTION
When the assets are served on "localhost", the server can only be accessed from the local machine. This poses a problem for developers running their server in a Homestead VM. Changing the host value to 0.0.0.0 allows larasset-js to serve the assets on all network interfaces.